### PR TITLE
[fix] 로그인 후 단어정보 요청시 발생하는 wordIds undefined 오류 해결

### DIFF
--- a/client/src/components/Word/AddWord.tsx
+++ b/client/src/components/Word/AddWord.tsx
@@ -17,7 +17,7 @@ export default function AddWord(props: { wordId: number }) {
 
   const [wordInWords, setWordInWords] = useState(false);
   useEffect(() => {
-    if (user.memberStatus)
+    if (user.memberStatus && data)
       data.wordIds.includes(props.wordId)
         ? setWordInWords(true)
         : setWordInWords(false);


### PR DESCRIPTION
## 작업내용
로그인 후 단어정보 요청시 발생하는 wordIds undefined 오류 해결
## 참고사항

## 기타
